### PR TITLE
msim: fix parse error when roaming with slot 2 only

### DIFF
--- a/src/java/com/android/internal/telephony/ServiceStateTracker.java
+++ b/src/java/com/android/internal/telephony/ServiceStateTracker.java
@@ -1121,7 +1121,10 @@ public abstract class ServiceStateTracker extends Handler {
     protected abstract void setRoamingType(ServiceState currentServiceState);
 
     protected String getHomeOperatorNumeric() {
-        return SystemProperties.get(TelephonyProperties.PROPERTY_ICC_OPERATOR_NUMERIC, "");
+        final Context context = mPhoneBase.getContext();
+        final TelephonyManager tm =
+                (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
+        return tm.getSimOperatorNumericForPhone(mPhoneBase.getPhoneId());
     }
 
     protected int getPhoneId() {


### PR DESCRIPTION
Need to parse the home operator numeric w.r.t. the phoneId.  Looks like this
bug was introduced with a merge from caf.

Change-Id: Ibee79ae193eb59e952c7cc63faaae3890230ab8e